### PR TITLE
Load parent configs and try simplified inheritance - followup after MDACH

### DIFF
--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -81,7 +81,9 @@ jobs:
           rm -rf plugin/tests/behatbu
 
       - name: Install moodle-plugin-ci
-        run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+        run: |
+          moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+          moodle-plugin-ci add-config '$CFG->behat_increasetimeout = 3;'
         env:
           DB: ${{ matrix.database }}
           MOODLE_BRANCH: ${{ matrix.moodle-branch }}

--- a/config.php
+++ b/config.php
@@ -28,11 +28,15 @@ defined('MOODLE_INTERNAL') || die();
 // Let codechecker ignore some sniffs for this file as we do not need a login check here..
 // phpcs:disable moodle.Files.RequireLogin.Missing
 
+// Add Boost Union and Boost settings as defaults.
+/** @var theme_config $THEME */
+$THEME->settings = (object)((array)$THEME->settings + (array)get_config('theme_boost_union') + (array)get_config('theme_boost'));
+
 // As a start, inherit the whole theme config from Boost Union.
 // This move will save us from duplicating all lines from Boost Union's config.php into Boost Union Child's config.php.
 // This statement uses require (and not require_once) by purpose to make sure that all Boost Union settings are added
 // to the $THEME object even if the Boost Union config was already included in some other place.
-require($CFG->dirroot . '/theme/boost_union/config.php');
+require(__DIR__ . '/../boost_union/config.php');
 
 // Then, we require Boost Union Child's locallib.php to make sure that it's always loaded.
 require_once($CFG->dirroot . '/theme/boost_union_child/locallib.php');
@@ -45,32 +49,3 @@ $THEME->scss = function($theme) {
 $THEME->parents = ['boost_union', 'boost'];
 $THEME->extrascsscallback = 'theme_boost_union_child_get_extra_scss';
 $THEME->prescsscallback = 'theme_boost_union_child_get_pre_scss';
-
-// We need to duplicate the rendererfactory even if it is set to the same value as in Boost Union.
-// The theme_config::get_renderer() method needs it to be directly in the theme_config object.
-$THEME->rendererfactory = 'theme_overridden_renderer_factory';
-
-// Lastly, we replicate some settings from Boost Union at runtime into Boost Union Child's settings.
-// This becomes necessary if Moodle core code accesses a theme setting at $this->page->theme->settings->*.
-// In this case, the setting must exist in the currently active theme, otherwise it won't be found.
-// While Boost Union duplicates all settings from Boost Core and does not suffer from this issue,
-// it would be quite ugly to duplicate all of these settings again to Boost Union Child.
-// Currently, this affects these Boost Core settings:
-// unaddableblocks - called from blocklib.php.
-$unaddableblocks = get_config('theme_boost_union', 'unaddableblocks');
-if (!empty($unaddableblocks)) {
-    $THEME->settings->unaddableblocks = $unaddableblocks;
-}
-unset($unaddableblocks);
-// SCSS - called in theme_boost_get_extra_scss.
-$scss = get_config('theme_boost_union', 'scss');
-if (!empty($scss)) {
-    $THEME->settings->scss = $scss;
-}
-unset($scss);
-// SCSSpre - called in theme_boost_get_pre_scss.
-$scsspre = get_config('theme_boost_union', 'scsspre');
-if (!empty($scsspre)) {
-    $THEME->settings->scsspre = $scsspre;
-}
-unset($scsspre);

--- a/lang/en/theme_boost_union_child.php
+++ b/lang/en/theme_boost_union_child.php
@@ -35,17 +35,6 @@ $string['configtitle'] = 'Boost Union Child';
 $string['settingsoverview_buc_desc'] = 'With Boost Union Child, you can customize Boost Union to your own local needs.';
 
 // Settings: General settings tab.
-// ... Section: Inheritance.
-$string['inheritanceheading'] = 'Inheritance';
-$string['inheritanceinherit'] = 'Inherit';
-$string['inheritanceduplicate'] = 'Duplicate';
-$string['inheritanceoptionsexplanation'] = 'Most of the time, inheriting will be perfectly fine. However, it may happen that imperfect code is integrated into Boost Union which prevents simple SCSS inheritance for particular Boost Union features. If you encounter any issues with Boost Union features which seem not to work in Boost Union Child as well, try to switch this setting to \'Dupliate\' and, if this solves the problem, report an issue on Github (see the README.md file for details how to report an issue).';
-// ... ... Setting: Pre SCSS inheritance setting.
-$string['prescssinheritancesetting'] = 'Pre SCSS inheritance';
-$string['prescssinheritancesetting_desc'] = 'With this setting, you control if the pre SCSS code from Boost Union should be inherited or duplicated.';
-// ... ... Setting: Extra SCSS inheritance setting.
-$string['extrascssinheritancesetting'] = 'Extra SCSS inheritance';
-$string['extrascssinheritancesetting_desc'] = 'With this setting, you control if the extra SCSS code from Boost Union should be inherited or duplicated.';
 
 /**************************************************************
  * EXTENSION POINT:

--- a/lib.php
+++ b/lib.php
@@ -22,10 +22,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-// Constants which are use throughout this theme.
-define('THEME_BOOST_UNION_CHILD_SETTING_INHERITANCE_INHERIT', 0);
-define('THEME_BOOST_UNION_CHILD_SETTING_INHERITANCE_DUPLICATE', 1);
-
 /**
  * Returns the main SCSS content.
  *
@@ -40,7 +36,7 @@ function theme_boost_union_child_get_main_scss_content($theme) {
 
     // As a start, get the compiled main SCSS from Boost Union.
     // This way, Boost Union Child will ship the same SCSS code as Boost Union itself.
-    $scss = theme_boost_union_get_main_scss_content(\core\output\theme_config::load('boost_union'));
+    $scss = theme_boost_union_get_main_scss_content($theme);
 
     // And add Boost Union Child's main SCSS file to the stack.
     $scss .= file_get_contents($CFG->dirroot . '/theme/boost_union_child/scss/post.scss');
@@ -57,22 +53,11 @@ function theme_boost_union_child_get_main_scss_content($theme) {
 function theme_boost_union_child_get_pre_scss($theme) {
     global $CFG;
 
-    // Require the necessary libraries.
-    require_once($CFG->dirroot . '/theme/boost_union/lib.php');
+    // NOTE: $THEME->prescsscallback was already called from all parent themes with $THEME->settings
+    // object that contains settings of this theme merged with parent themes settings.
 
     // As a start, initialize the Pre SCSS code with an empty string.
     $scss = '';
-
-    // Then, if configured, get the compiled pre SCSS code from Boost Union.
-    // This should not be necessary as Moodle core calls the *_get_pre_scss() functions from all parent themes as well.
-    // However, as soon as Boost Union would use $theme->settings in this function, $theme would be this theme here and
-    // not Boost Union. The Boost Union developers are aware of this topic, but faults can always happen.
-    // If such a fault happens, the Boost Union Child administrator can switch the inheritance to 'Duplicate'.
-    // This way, we will add the pre SCSS code with the explicit use of the Boost Union configuration to the stack.
-    $inheritanceconfig = get_config('theme_boost_union_child', 'prescssinheritance');
-    if ($inheritanceconfig == THEME_BOOST_UNION_CHILD_SETTING_INHERITANCE_DUPLICATE) {
-        $scss .= theme_boost_union_get_pre_scss(\core\output\theme_config::load('boost_union'));
-    }
 
     // And add Boost Union Child's pre SCSS file to the stack.
     $scss .= file_get_contents($CFG->dirroot . '/theme/boost_union_child/scss/pre.scss');
@@ -95,22 +80,11 @@ function theme_boost_union_child_get_pre_scss($theme) {
 function theme_boost_union_child_get_extra_scss($theme) {
     global $CFG;
 
-    // Require the necessary libraries.
-    require_once($CFG->dirroot . '/theme/boost_union/lib.php');
+    // NOTE: $THEME->extrascsscallback was already called from all parent themes with $THEME->settings
+    // object that contains settings of this theme merged with parent themes settings.
 
     // As a start, initialize the Extra SCSS code with an empty string.
     $scss = '';
-
-    // Then, if configured, get the compiled extra SCSS code from Boost Union.
-    // This should not be necessary as Moodle core calls the *_get_extra_scss() functions from all parent themes as well.
-    // However, as soon as Boost Union would use $theme->settings in this function, $theme would be this theme here and
-    // not Boost Union. The Boost Union developers are aware of this topic, but faults can always happen.
-    // If such a fault happens, the Boost Union Child administrator can switch the inheritance to 'Duplicate'.
-    // This way, we will add the extra SCSS code with the explicit use of the Boost Union configuration to the stack.
-    $inheritanceconfig = get_config('theme_boost_union_child', 'extrascssinheritance');
-    if ($inheritanceconfig == THEME_BOOST_UNION_CHILD_SETTING_INHERITANCE_DUPLICATE) {
-        $scss .= theme_boost_union_get_extra_scss(\core\output\theme_config::load('boost_union'));
-    }
 
     /**********************************************************
      * EXTENSION POINT:

--- a/settings.php
+++ b/settings.php
@@ -80,40 +80,6 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         $tab = new admin_settingpage('theme_boost_union_child_general',
                 get_string('generalsettings', 'theme_boost', null, true));
 
-        // Create inheritance heading.
-        $name = 'theme_boost_union_child/inheritanceheading';
-        $title = get_string('inheritanceheading', 'theme_boost_union_child', null, true);
-        $setting = new admin_setting_heading($name, $title, null);
-        $tab->add($setting);
-
-        // Prepare inheritance options.
-        $inheritanceoptions = [
-                THEME_BOOST_UNION_CHILD_SETTING_INHERITANCE_INHERIT =>
-                        get_string('inheritanceinherit', 'theme_boost_union_child'),
-                THEME_BOOST_UNION_CHILD_SETTING_INHERITANCE_DUPLICATE =>
-                        get_string('inheritanceduplicate', 'theme_boost_union_child'),
-        ];
-
-        // Setting: Pre SCSS inheritance setting.
-        $name = 'theme_boost_union_child/prescssinheritance';
-        $title = get_string('prescssinheritancesetting', 'theme_boost_union_child', null, true);
-        $description = get_string('prescssinheritancesetting_desc', 'theme_boost_union_child', null, true).'<br />'.
-                get_string('inheritanceoptionsexplanation', 'theme_boost_union_child', null, true);
-        $setting = new admin_setting_configselect($name, $title, $description,
-                THEME_BOOST_UNION_CHILD_SETTING_INHERITANCE_INHERIT, $inheritanceoptions);
-        $setting->set_updatedcallback('theme_reset_all_caches');
-        $tab->add($setting);
-
-        // Setting: Extra SCSS inheritance setting.
-        $name = 'theme_boost_union_child/extrascssinheritance';
-        $title = get_string('extrascssinheritancesetting', 'theme_boost_union_child', null, true);
-        $description = get_string('extrascssinheritancesetting_desc', 'theme_boost_union_child', null, true).'<br />'.
-                get_string('inheritanceoptionsexplanation', 'theme_boost_union_child', null, true);
-        $setting = new admin_setting_configselect($name, $title, $description,
-                THEME_BOOST_UNION_CHILD_SETTING_INHERITANCE_INHERIT, $inheritanceoptions);
-        $setting->set_updatedcallback('theme_reset_all_caches');
-        $tab->add($setting);
-
         // Add tab to settings page.
         $page->add($tab);
 


### PR DESCRIPTION
Hello Alexander,

here is the promised code that attempts to simplify settings inheritance.

The original idea of settings inheritance was that admins should be able to create pretty much empty classic theme and just add new setting with the same name and load parent settings. Unfortunately when Boost was introduced the devs did not have full understanding of original classic theme architecture it seems.

Anyway, there do not seem to be any new regressions in Github CI compared to pre-existing CI a(you can compare it with https://github.com/skodak/moodle-theme_boost_union_child/actions/runs/17718325253)

I was thinking more about the snippets and sub-plugins, I guess it might be a lot easier approach for most users of your theme to customise their sites with extra code and CSS. I'll try to create a sample patch later this week.

Petr 